### PR TITLE
Adds debug() calls to all files

### DIFF
--- a/bin/dsafio-config.js
+++ b/bin/dsafio-config.js
@@ -66,7 +66,7 @@ switch (operation) {
       .catch(error => {
         debug(error)
 
-        ['EACCES', 'ENOENT'].includes(error.code)
+        ;['EACCES', 'ENOENT'].includes(error.code)
           ? console.error('Inaccessible or inexistent configuration file')
           : console.error('Something went wrong while reading configuration file')
         process.exit(1)

--- a/bin/dsafio-config.js
+++ b/bin/dsafio-config.js
@@ -29,6 +29,7 @@ switch (operation) {
     debug(`arguments: ${args}`)
 
     debug('loading configuration')
+
     config.get(args)
       .then(entries => {
         debug('configuration loaded:', entries)

--- a/bin/dsafio-config.js
+++ b/bin/dsafio-config.js
@@ -6,11 +6,15 @@ const pkg     = require('../package.json')
 const config  = require('../lib/config')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dsafio/cli/config')
+debug('running dsafio-config')
+
 program
   .version(pkg.version)
   .parse(process.argv)
 
 const operation = program.args.shift()
+debug(`operation: ${operation}`)
 
 if (!['get', 'set'].includes(operation)) {
   console.error('Invalid config operation. See --help for more info.')
@@ -22,14 +26,22 @@ switch (operation) {
     var args
 
     if (program.args.length) args = program.args
+    debug(`arguments: ${args}`)
 
+    debug('loading configuration')
     config.get(args)
-      .then(entries => Object.keys(entries)
-        .map(key => `${key}=${entries[key]}`)
-        .join('\n'))
+      .then(entries => {
+        debug('configuration loaded:', entries)
+
+        return Object.keys(entries)
+          .map(key => `${key}=${entries[key]}`)
+          .join('\n')
+      })
       .then(console.info.bind(console))
       .catch(error => {
-        ['EACCES', 'ENOENT'].includes(error.code)
+        debug(error)
+
+        ;['EACCES', 'ENOENT'].includes(error.code)
           ? console.error('Inaccessible or inexistent configuration file')
           : console.error('Something went wrong while reading configuration file')
         process.exit(1)
@@ -45,8 +57,14 @@ switch (operation) {
 
         return { [program.args[0]]: program.args[1] }
       })
-      .then(config.set)
+      .then(entries => {
+        debug('setting configuration:', entries)
+
+        config.set(entries)
+      })
       .catch(error => {
+        debug(error)
+
         ['EACCES', 'ENOENT'].includes(error.code)
           ? console.error('Inaccessible or inexistent configuration file')
           : console.error('Something went wrong while reading configuration file')

--- a/bin/dsafio-update.js
+++ b/bin/dsafio-update.js
@@ -6,12 +6,18 @@ const pkg      = require('../package.json')
 const registry = require('../lib/registry')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dsafio/cli/update')
+debug('running dsafio-update')
+
+
 program
   .version(pkg.version)
   .parse(process.argv)
 
 registry.update()
   .catch(() => {
+    debug(error)
+
     console.error('Something went wrong while updating the registry')
     process.exit(1)
   })

--- a/bin/dsafio-update.js
+++ b/bin/dsafio-update.js
@@ -9,13 +9,12 @@ const registry = require('../lib/registry')
 const debug = require('debug')('dsafio/cli/update')
 debug('running dsafio-update')
 
-
 program
   .version(pkg.version)
   .parse(process.argv)
 
 registry.update()
-  .catch(() => {
+  .catch(error => {
     debug(error)
 
     console.error('Something went wrong while updating the registry')

--- a/bin/dsafio.js
+++ b/bin/dsafio.js
@@ -5,6 +5,9 @@ const program = require('commander')
 const pkg     = require('../package.json')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dsafio/cli')
+debug('bootstrapping cli')
+
 program
   .version(pkg.version)
   .command('config <get|set> [key=value...]', 'get/set user configuration')

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -46,7 +46,7 @@ function fetch (keys, options) {
     return fetchInDisk(keys, options)
   }
 
-  debug("fetch(): getting challenges from registry")
+  debug('fetch(): getting challenges from registry')
 
   return registry.get(['challenges'])
     .then(registry => registry.challenges)

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -7,7 +7,11 @@ const fs       = require('./fs-as-promise')
 const registry = require('./registry')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dasfio/lib/challenge')
+debug('lib/challenge running')
+
 const DSAFIO_DATA_HOME = process.env.DSAFIO_DATA_HOME || process.env.XGD_DATA_HOME || `${os.homedir()}/dsafio`
+debug(`DSAFIO_DATA_HOME: ${DSAFIO_DATA_HOME}`)
 
 const CHALLENGES_BASE_URL = 'https://api.github.com/repos/dsafio/challenges/contents/challenges'
 
@@ -22,21 +26,29 @@ const CHALLENGES_BASE_URL = 'https://api.github.com/repos/dsafio/challenges/cont
  * @see https://github.com/dsafio/challenges/blob/master/registry.json
  */
 function fetch (keys, options) {
+  debug('fetch() running')
+
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
+    debug(`fetch(): invalid argument 'key': ${typeof keys} ${keys}`)
     return Promise.reject(new Error('challenge.fetch() accepts an array of challenge keys'))
   }
 
   if (![null, undefined].includes(options) && options.constructor !== Object) {
+    debug(`fetch(): invalid argument 'options': ${typeof options} ${options}`)
     return Promise.reject(new Error("'options' must be an object"))
   }
 
   if (options && options.inDisk) {
+    debug('fetch(): options.inDisk is on. proceeding with fetchInDisk()')
     return fetchInDisk(keys, options)
   }
 
+  debug("fetch(): getting challenges from registry")
   return registry.get(['challenges'])
     .then(registry => registry.challenges)
     .then(challenges => {
+      debug(`fetch(): filtering challenges`)
+
       if (!keys) {
         return challenges
       }
@@ -50,12 +62,14 @@ function fetch (keys, options) {
       }, {})
     })
     .then(challenges => {
+      debug('fetch(): challenges filtered. proceeding with file downloads')
       return Promise.all(Object.keys(challenges).map(challenge => {
         return Promise.all([
           'index.js',
           'readme.md',
           'test.js'
         ].map(filename => {
+          debug(`fetch(): requesting file '${filename}' of challenge '${challenge}'`)
           return request.get(`${CHALLENGES_BASE_URL}/${challenge}/${filename}`, {
             headers: { 'User-Agent': 'dsafio/dsafio' }
           })
@@ -74,14 +88,20 @@ function fetch (keys, options) {
 }
 
 function fetchInDisk (keys, options) {
+  debug('fetchInDisk(): running')
+
+  debug('fetchInDisk(): trying to create DSAFIO_DATA_HOME')
   return mkdirp(DSAFIO_DATA_HOME)
     .then(fetch(keys))
     .then(challenges => {
+      debug('fetchInDisk(): challenges loaded. proceeding to disk writes')
       return Promise.all(challenges.map(challenge => {
+        debug(`fetchInDisk(): creating folder '${DSAFIO_DATA_HOME}/${challenge.title}'`)
         return mkdirp(`${DSAFIO_DATA_HOME}/${challenge.title}`)
           .then(() => {
             return Promise.all(challenge.files.map(function (file) {
               const filepath = `${DSAFIO_DATA_HOME}/${challenge.title}/${file.name}`
+              debug(`fetchInDisk(): writing file '${filepath}'`)
               return fs.writeFile(filepath, file.content, 'utf8')
             }))
           })

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -30,20 +30,24 @@ function fetch (keys, options) {
 
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
     debug(`fetch(): invalid argument 'key': ${typeof keys} ${keys}`)
+
     return Promise.reject(new Error('challenge.fetch() accepts an array of challenge keys'))
   }
 
   if (![null, undefined].includes(options) && options.constructor !== Object) {
     debug(`fetch(): invalid argument 'options': ${typeof options} ${options}`)
+
     return Promise.reject(new Error("'options' must be an object"))
   }
 
   if (options && options.inDisk) {
     debug('fetch(): options.inDisk is on. proceeding with fetchInDisk()')
+
     return fetchInDisk(keys, options)
   }
 
   debug("fetch(): getting challenges from registry")
+
   return registry.get(['challenges'])
     .then(registry => registry.challenges)
     .then(challenges => {
@@ -63,6 +67,7 @@ function fetch (keys, options) {
     })
     .then(challenges => {
       debug('fetch(): challenges filtered. proceeding with file downloads')
+
       return Promise.all(Object.keys(challenges).map(challenge => {
         return Promise.all([
           'index.js',
@@ -70,6 +75,7 @@ function fetch (keys, options) {
           'test.js'
         ].map(filename => {
           debug(`fetch(): requesting file '${filename}' of challenge '${challenge}'`)
+
           return request.get(`${CHALLENGES_BASE_URL}/${challenge}/${filename}`, {
             headers: { 'User-Agent': 'dsafio/dsafio' }
           })
@@ -95,13 +101,17 @@ function fetchInDisk (keys, options) {
     .then(fetch(keys))
     .then(challenges => {
       debug('fetchInDisk(): challenges loaded. proceeding to disk writes')
+
       return Promise.all(challenges.map(challenge => {
         debug(`fetchInDisk(): creating folder '${DSAFIO_DATA_HOME}/${challenge.title}'`)
+
         return mkdirp(`${DSAFIO_DATA_HOME}/${challenge.title}`)
           .then(() => {
             return Promise.all(challenge.files.map(function (file) {
               const filepath = `${DSAFIO_DATA_HOME}/${challenge.title}/${file.name}`
+
               debug(`fetchInDisk(): writing file '${filepath}'`)
+
               return fs.writeFile(filepath, file.content, 'utf8')
             }))
           })

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,19 +3,21 @@ const os = require('os')
 const fs = require('./fs-as-promise')
 /* eslint-enable no-multi-spaces */
 
-const debug = require('debug')('dsafio-config')
+const debug = require('debug')('dsafio/lib/config')
+debug('lib/config running')
 
 const DSAFIO_CONFIG_FILE = process.env.DSAFIO_CONFIG_FILE || `${os.homedir()}/.dsafiorc`
+debug(`DSAFIO_CONFIG_FILE: ${DSAFIO_CONFIG_FILE}`)
 
 function get (keys) {
   debug('get(): running')
 
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
-    debug('get(): invalid argument')
+    debug(`get(): invalid argument: ${typeof keys} ${keys}`)
     return Promise.reject(new Error('config.get() accepts an array of configuration keys'))
   }
 
-  debug('get(): reading user configuration')
+  debug('get(): reading configuration')
   return fs.readFile(DSAFIO_CONFIG_FILE, 'utf8')
     .then(contents => {
       contents = contents.trim().length
@@ -46,22 +48,23 @@ function set (entries) {
   debug('set(): running')
 
   if (typeof entries !== 'object' || !Object.keys(entries).length) {
-    debug('set(): invalid argument')
+    debug(`set(): invalid argument: ${typeof entries} ${entries}`)
     return Promise.reject(new Error('config.set() requires an object with configuration key/value pairs'))
   }
 
-  debug('set(): arguments are ok. processing')
+  debug('set(): reading configuration')
   return get()
     .catch(error => {
       // ENOENT errors (file absence) will be ignored
       if (error.code === 'ENOENT') {
+        debug('configuration file absent. proceeding with fallback')
         return {}
       }
 
       throw error
     })
     .then(prevConfig => {
-      debug('set(): merging configurations')
+      debug('set(): merging current and new configuration')
       return Object.assign({}, prevConfig, entries)
     })
     .then(config => {
@@ -69,7 +72,7 @@ function set (entries) {
       return JSON.stringify(config, null, '  ')
     })
     .then(json => {
-      debug('set(): writing user configuration')
+      debug('set(): writing configuration')
       return fs.writeFile(DSAFIO_CONFIG_FILE, json, 'utf8')
     })
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,10 +14,12 @@ function get (keys) {
 
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
     debug(`get(): invalid argument: ${typeof keys} ${keys}`)
+
     return Promise.reject(new Error('config.get() accepts an array of configuration keys'))
   }
 
   debug('get(): reading configuration')
+
   return fs.readFile(DSAFIO_CONFIG_FILE, 'utf8')
     .then(contents => {
       contents = contents.trim().length
@@ -25,6 +27,7 @@ function get (keys) {
         : '{}'
 
       debug('get(): parsing JSON')
+
       return JSON.parse(contents)
     })
     .then(config => {
@@ -49,15 +52,18 @@ function set (entries) {
 
   if (typeof entries !== 'object' || !Object.keys(entries).length) {
     debug(`set(): invalid argument: ${typeof entries} ${entries}`)
+
     return Promise.reject(new Error('config.set() requires an object with configuration key/value pairs'))
   }
 
   debug('set(): reading configuration')
+
   return get()
     .catch(error => {
       // ENOENT errors (file absence) will be ignored
       if (error.code === 'ENOENT') {
         debug('configuration file absent. proceeding with fallback')
+
         return {}
       }
 
@@ -65,14 +71,17 @@ function set (entries) {
     })
     .then(prevConfig => {
       debug('set(): merging current and new configuration')
+
       return Object.assign({}, prevConfig, entries)
     })
     .then(config => {
       debug('set(): generating JSON')
+
       return JSON.stringify(config, null, '  ')
     })
     .then(json => {
       debug('set(): writing configuration')
+
       return fs.writeFile(DSAFIO_CONFIG_FILE, json, 'utf8')
     })
 }

--- a/lib/fs-as-promise.js
+++ b/lib/fs-as-promise.js
@@ -3,6 +3,9 @@ const fs   = require('fs')
 const util = require('util')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dsafio/lib/fs-as-promise')
+debug('lib/fs-as-promise running')
+
 module.exports = {
   readFile: util.promisify(fs.readFile),
   writeFile: util.promisify(fs.writeFile)

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -32,11 +32,13 @@ function get (keys) {
 
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
     debug(`get(): invalid argument: ${typeof keys} ${keys}`)
+
     return Promise.reject(new Error('registry.get() accepts an array of configuration keys'))
   }
 
   if (REGISTRY) {
     debug('get(): returning registry from memory cache')
+
     return Promise.resolve(Object.assign({}, REGISTRY))
   }
 
@@ -47,6 +49,7 @@ function get (keys) {
     .catch(error => {
       if (error.code === 'ENOENT') {
         debug('registry file absent. loading from github api')
+
         return loadFromApi()
       }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -6,6 +6,9 @@ const request = require('request-promise-native')
 const fs      = require('./fs-as-promise')
 /* eslint-enable no-multi-spaces */
 
+const debug = require('debug')('dsafio/lib/registry')
+debug('lib/registry running')
+
 /**
  * Holds the entire registry in RAM.
  */
@@ -17,38 +20,52 @@ var REGISTRY = null
  * @see XDG Base Directory Specification https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
  */
 const DSAFIO_CACHE_HOME = (process.env.DSAFIO_CACHE_HOME || process.env.XDG_CACHE_HOME || `${os.homedir()}/.cache`).concat('/dsafio')
+debug(`DSAFIO_CACHE_HOME: ${DSAFIO_CACHE_HOME}`)
 
 const DSAFIO_CACHE_FILE = process.env.DSAFIO_CACHE_FILE || `${DSAFIO_CACHE_HOME}/registry.json`
+debug(`DSAFIO_CACHE_FILE: ${DSAFIO_CACHE_FILE}`)
 
 const API_BASE_URL = 'https://api.github.com'
 
 function get (keys) {
+  debug('get(): running')
+
   if (keys !== undefined && (!Array.isArray(keys) || !keys.length)) {
+    debug(`get(): invalid argument: ${typeof keys} ${keys}`)
     return Promise.reject(new Error('registry.get() accepts an array of configuration keys'))
   }
 
-  const chain = Promise.resolve()
+  if (REGISTRY) {
+    debug('get(): returning registry from memory cache')
+    return Promise.resolve(Object.assign({}, REGISTRY))
+  }
 
-  return REGISTRY
-    ? Promise.resolve(Object.assign({}, REGISTRY))
-    : chain.then(loadFromDisk)
-        .catch(error => {
-          if (error.code === 'ENOENT') {
-            return loadFromApi()
-          }
+  debug('get(): memory cache empty. reading registry file from disk')
 
-          throw error
-        })
-        .then(cacheOnMemory)
-        .then(cacheOnDisk)
+  return Promise.resolve()
+    .then(loadFromDisk)
+    .catch(error => {
+      if (error.code === 'ENOENT') {
+        debug('registry file absent. loading from github api')
+        return loadFromApi()
+      }
+
+      throw error
+    })
+    .then(cacheOnMemory)
+    .then(cacheOnDisk)
 }
 
 function loadFromDisk () {
+  debug('loadFromDisk(): running')
+
   return fs.readFile(DSAFIO_CACHE_FILE, 'utf8')
     .then(JSON.parse)
 }
 
 function loadFromApi () {
+  debug('loadFromApi(): running')
+
   return request.get(`${API_BASE_URL}/repos/dsafio/challenges/contents/registry.json`, {
     headers: { 'User-Agent': 'dsafio/dsafio' }
   })
@@ -59,16 +76,22 @@ function loadFromApi () {
 }
 
 function cacheOnMemory (registry) {
+  debug('cacheOnMemory(): running')
+
   return Promise.resolve(REGISTRY = Object.assign({}, registry))
 }
 
 function cacheOnDisk (registry) {
+  debug('cacheOnMemory(): running')
+
   return mkdirp(DSAFIO_CACHE_HOME)
     .then(() => fs.writeFile(DSAFIO_CACHE_FILE, JSON.stringify(registry), 'utf8'))
     .then(() => registry)
 }
 
 function update () {
+  debug('update(): running')
+
   return loadFromApi()
     .then(cacheOnMemory)
     .then(cacheOnDisk)


### PR DESCRIPTION
To activate verbose/debugging logs, set `DEBUG` to something like `dsafio/*`. E.g.:

```
DEBUG=dsafio/* dsafio config get
```

All files are specifically tagged for better debugging activation/deactivation. Tags in the `bin` folder are prefixed with `dsafio/cli`; tags in `lib` are prefixed with `dsafio/lib` (e.g.: `bin/dsafio-config.js` is tagged with `dsafio/lib/config`, and `lib/config.js` is tagged with `dsafio/lib/config`).

[debug](https://www.npmjs.com/package/debug) supports specific activation. You can activate multiple tags using commas, or activate entire groups using wildcards:

```
# activates a single tag:
DEBUG=dsafio/lib/config dsafio config get

# activates two specific tags
DEBUG=dsafio/bin/config,dsafio/lib/config dsafio config get

# activates many tags using wildcards
DEBUG=dsafio/lib/* dsafio config get
```