### PR TITLE
Updates debug to 3.1.0 to address RegExDoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "commander": "^2.11.0",
-    "debug": "^3.0.1",
+    "debug": "^3.1.0",
     "got": "^7.1.0",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
See https://nodesecurity.io/advisories/534