### PR TITLE
Sticks Debug version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "commander": "^2.11.0",
-    "debug": "^3.1.0",
+    "debug": "3.1.0",
     "got": "^8.0.0",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
A Debug maintainer released a breaking change version of the library without bumping its major version, suddenly breaking a considerable amount of Node.js projects. This commit sticks the latest working version of Debug.

This is an ad-hoc solution and must be reverted as soon as a non-breaking 3.x release of Debug is made.

See visionmedia/debug#603