### PR TITLE
Removes `-b` from script `test:watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "test": "mocha -b --recursive",
-    "test:watch": "mocha -bw --recursive",
+    "test:watch": "mocha -w --recursive",
     "lint": "standard --verbose"
   },
   "dependencies": {


### PR DESCRIPTION
Somehow `-b` was keeping Mocha from keep running on the terminal. By
removing the `-b` flag, Mocha were able to watch for changes properly.